### PR TITLE
Use cat and array lookup for metrics

### DIFF
--- a/file_handles.sh
+++ b/file_handles.sh
@@ -15,9 +15,10 @@ while sleep "$INTERVAL"; do
   # Linux 2.6 always reports 0 as the number of free file handles -- this is not an error, it just means that the number of allocated file handles exactly matches the number of used file handles.
 
   # Grab the metrics
-  allocated=$(cut -f1 /proc/sys/fs/file-nr)
-  allunused=$(cut -f2 /proc/sys/fs/file-nr)
-  max=$(cut -f3 /proc/sys/fs/file-nr)
+  file_nr=($(cat /proc/sys/fs/file-nr))
+  allocated=${file_nr[0]}
+  allunused=${file_nr[1]}
+  max=${file_nr[2]}
 
   # Output time
   echo "PUTVAL $HOSTNAME/system-file_handles/gauge-file_handles_used interval=$INTERVAL N:$allocated"


### PR DESCRIPTION
Suggested to me by @quixoten:

> Reduces the number of forking operations and avoids repeatedly reading the same file. Just to be sure I ran 10,000 iterations of each. Removing the extra reads and forks reduced 26.290s down to 9.158s. 
